### PR TITLE
fix: config

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -1,4 +1,9 @@
 import { createConfig } from '@nx/angular-rspack';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export default createConfig({
     options: {


### PR DESCRIPTION
fixes the following:

```
ReferenceError: __dirname is not defined
    at /angular-rspack-ng-cli-example/rspack.config.ts:5:15
```

@Coly010 